### PR TITLE
3D modeli za Miloja

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.f3d filter=lfs diff=lfs merge=lfs -text
+*.stl filter=lfs diff=lfs merge=lfs -text
+*.step filter=lfs diff=lfs merge=lfs -text

--- a/models/adapter_prednji_tocak.f3d
+++ b/models/adapter_prednji_tocak.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6651dc2914d3322bc6b8d393ff4839233d716c615d8bd92f769c80abb3400314
+size 54834

--- a/models/adapter_prednji_tocak.stl
+++ b/models/adapter_prednji_tocak.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58bfbcc17b6f8bb9f3917f445e442874b93abfd9550ab1c377a94ed7cd238482
+size 18884

--- a/models/adapter_zadnji_tockovi.f3d
+++ b/models/adapter_zadnji_tockovi.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb0e0baf7c6fc2eacf6287135eaebeff03fce89302e1fbcd150f9c4223ac74be
+size 68123

--- a/models/adapter_zadnji_tockovi.stl
+++ b/models/adapter_zadnji_tockovi.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:672510d2ca4b736fc953e1f93859c05e68f6c0bc4dc6a08579c6b088785c8f0b
+size 109984

--- a/models/drzac_baterija.f3d
+++ b/models/drzac_baterija.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4d342c388e1f641c70a44e6f3a4526953ff6e8d17881953b1ffd4eb72e5da30
+size 103963

--- a/models/drzac_baterija.stl
+++ b/models/drzac_baterija.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c38f60784a277df90a6d94bb314c16ff19fb331582da229e9670e5a255450126
+size 50284

--- a/models/drzac_on_off_dugme.step
+++ b/models/drzac_on_off_dugme.step
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1e98ce864da19bc6af22c4d211913b0d00498fd282922ae8d3e30c1a8ff271a
+size 24739

--- a/models/drzac_on_off_dugme.stl
+++ b/models/drzac_on_off_dugme.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:045a3b01317f93351c93bf762dc5bb82dc6d4fcba3320ee53094c5c385c18e72
+size 36884

--- a/models/drzac_stepper_desni.f3d
+++ b/models/drzac_stepper_desni.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd0350d4554e367edb1e595dfa69ee7b4485360e1cad3ba55e9eaae2a253bc1e
+size 211089

--- a/models/drzac_stepper_desni.stl
+++ b/models/drzac_stepper_desni.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:871524f86d6cb9885be96795ebf05912281ce872adb6dc23648d64d3db6e9bd6
+size 100584

--- a/models/drzac_stepper_levi.f3d
+++ b/models/drzac_stepper_levi.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78eb2a83753d781ee7c278f655c5dfcf3f125a71eaaccb556876e16037eeda72
+size 225513

--- a/models/drzac_stepper_levi.stl
+++ b/models/drzac_stepper_levi.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb3a81e4cea8afda652dfb07069f91bbeb8ec3d80092f87efc87dac8a0b638a7
+size 100784

--- a/models/natpis_miloje.f3d
+++ b/models/natpis_miloje.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9daf688ccc10fc050f19c44841d1f4ae162aa72907fa193637a60f762263241
+size 144613

--- a/models/natpis_miloje.stl
+++ b/models/natpis_miloje.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dba5ef51f61634233c32b64f5cd56baa613afbf008e8c554925c5954c141bce2
+size 68484

--- a/models/platforma_arduino.f3d
+++ b/models/platforma_arduino.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e70a773f79fe55de9e5398f69b8962b208cc841ed9176644c16e13a865979d0
+size 193421

--- a/models/platforma_arduino.stl
+++ b/models/platforma_arduino.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56429726b840a8c202cb6c6b157c1be47e6a32c61555ecfc2a05690cb4e08478
+size 620684

--- a/models/platforma_gornja.f3d
+++ b/models/platforma_gornja.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ddc1ab4c7a51b842847e744c2006b0cd62114c5f40770f49be34b3ca154814
+size 226773

--- a/models/platforma_gornja.stl
+++ b/models/platforma_gornja.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1f3634bae79943f3b15cc10110d07ac93f5b15c9e93e8b23a9825409ce837df
+size 876284

--- a/models/ratkapne.f3d
+++ b/models/ratkapne.f3d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bbccb360eb79870f6db29a0851d1f293a7700934c453c92e81d46808876e384
+size 143371

--- a/models/ratkapne.stl
+++ b/models/ratkapne.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b42a0a06d6f00969b2598cd29643938cc6629b99fc0eab06f0aa9d666a13182
+size 80884


### PR DESCRIPTION
Dodati 3D modeli koji su dosad pravljeni za Miloja (#10). Većina ima svoje F3D fajlove, osim držača za bateriju koji je izvezen sa Onshape i takođe ga čuvamo na Onshape cloud.